### PR TITLE
Explicitly check for C++11 lambda support in configure

### DIFF
--- a/configure
+++ b/configure
@@ -4601,7 +4601,31 @@ $as_echo "$ac_res" >&6; }
   fi
 
 
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for C++11 lambda support" >&5
+$as_echo_n "checking for C++11 lambda support... " >&6; }
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
 
+int
+main ()
+{
+
+        auto l = []() {};
+  ;
+  return 0;
+}
+
+_ACEOF
+if ac_fn_cxx_try_compile "$LINENO"; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: ok" >&5
+$as_echo "ok" >&6; }
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: not available" >&5
+$as_echo "not available" >&6; }
+    as_fn_error $? "C++11 \"lambda\" support required; use g++ 4.7 or newer" "$LINENO" 5
+
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 
 ac_config_files="$ac_config_files Makefile"
 

--- a/configure.ac
+++ b/configure.ac
@@ -18,6 +18,13 @@ AC_LANG([C++])
 
 AX_CXX_COMPILE_STDCXX_11()
 
-
+AC_MSG_CHECKING([for C++11 lambda support])
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([], [
+        auto l = [[]]() {};])
+    ],
+    AC_MSG_RESULT(ok),
+    AC_MSG_RESULT(not available)
+    AC_MSG_ERROR([C++11 "lambda" support required; use g++ 4.7 or newer])
+)
 	
 AC_OUTPUT([Makefile])


### PR DESCRIPTION
This addresses issue 1 by testing for the required compiler support (it still doesn't allow building on g++4.4, though)
