### PR TITLE
use subdir-objects option on AM_INIT_AUTOMAKE

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 dnl Template file for configure.
 AC_INIT([dvdcopy], [0.1])
-AM_INIT_AUTOMAKE([foreign])
+AM_INIT_AUTOMAKE([foreign subdir-objects])
 
 # AC_CONFIG_MACRO_DIRS([/usr/share/aclocal])
 


### PR DESCRIPTION
As suggested by automake:

```
Makefile.am:3: warning: source file 'src/main.cc' is in a subdirectory,
Makefile.am:3: but option 'subdir-objects' is disabled
automake: warning: possible forward-incompatibility.
automake: At least a source file is in a subdirectory, but the 'subdir-objects'
automake: automake option hasn't been enabled.  For now, the corresponding output
automake: object file(s) will be placed in the top-level directory.  However,
automake: this behaviour will change in future Automake versions: they will
automake: unconditionally cause object files to be placed in the same subdirectory
automake: of the corresponding sources.
automake: You are advised to start using 'subdir-objects' option throughout your
automake: project, to avoid future incompatibilities.
```
